### PR TITLE
.jshintrc file instead of fixed JSHint options

### DIFF
--- a/scripts/run.js
+++ b/scripts/run.js
@@ -79,9 +79,9 @@
     // the source file or one dir above, then use this
     // configuration instead of the default one
     if (fs.existsSync(filename)) {
-        option = getOptions(filename);
+      option = getOptions(filename);
     } else if (fs.existsSync("../" + filename)) {
-        option = getOptions("../" + filename);
+      option = getOptions("../" + filename);
     }
 
     // read the source file and, when complete, lint the code


### PR DESCRIPTION
Hi there!

I was wondering why this nice ST Plugin doesn't support using `.jshintrc` files to validate JS-Code so I added this, in my eyes, necessary functionality.

The Plugin now looks for a `.jshintrc` file in the same directory (or one directory above if it doesn't exist) as the source file and uses this options instead of the default ones.

Hope you like it!

Cheers,
Miw0
