### PR TITLE
JSHint Now Shows Errors In Status Bars When Clicked On a Line With Errors

### DIFF
--- a/JSHint.py
+++ b/JSHint.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import sublime, sublime_plugin
-import os, sys, subprocess, codecs, webbrowser
+import os, re, sys, subprocess, codecs, webbrowser
 
 try:
   import commands
@@ -22,9 +22,7 @@ class JshintCommand(sublime_plugin.TextCommand):
       # Thus executing scripts *located inside this archive* via node.js
       # will, unfortunately, not be possible.
       url = "https://github.com/victorporof/Sublime-JSHint#manually"
-      msg = """You won't be able to use this plugin in Sublime Text 3 when \
-installed via the Package Manager.\n\nPlease remove it and install manually, \
-following the instructions at:\n"""
+      msg = """You won't be able to use this plugin in Sublime Text 3 when installed via the Package Manager.\n\nPlease remove it and install manually, following the instructions at:\n"""
       sublime.ok_cancel_dialog(msg + url)
       webbrowser.open(url)
       return
@@ -82,6 +80,7 @@ following the instructions at:\n"""
     if len(output) > 0:
       regions = []
       menuitems = []
+      JSHintListener.errors = []
 
       # For each line of jshint output (errors, warnings etc.) add a region
       # in the view and a menuitem in a quick panel.
@@ -92,6 +91,7 @@ following the instructions at:\n"""
           word = self.view.word(point)
           menuitems.append(lineNo + ":" + columnNo + " " + description)
           regions.append(word)
+          JSHintListener.errors.append((word, description))
         except:
           pass
 
@@ -138,6 +138,12 @@ class JshintClearAnnotationsCommand(sublime_plugin.TextCommand):
   def run(self, edit):
     self.view.erase_regions("jshint_errors")
 
+class JSHintListener(sublime_plugin.EventListener):
+  errors = []
+
+  def on_selection_modified(self, view):
+    display_to_status_bar(view)
+
 def open_jshintrc(window):
   window.open_file(PLUGIN_FOLDER + "/.jshintrc")
 
@@ -173,3 +179,25 @@ def get_output(cmd):
     # Handle all OS in Python 3.
     run = '"' + '" "'.join(cmd) + '"'
     return subprocess.check_output(run, stderr=subprocess.STDOUT, shell=True)
+
+def is_javascript(view):
+  return bool(re.search("JavaScript", view.settings().get('syntax'), re.I))
+
+def get_line_number(view, region):
+  return view.rowcol(region.end())[0]
+
+def display_to_status_bar(view):
+  if not is_javascript(view):
+    return
+
+  warnings = view.get_regions("jshint_errors")
+  for warning in warnings:
+    select_line = get_line_number(view, view.sel()[0])
+    warning_line = get_line_number(view, warning)
+    if select_line == warning_line:
+      for reg, err in JSHintListener.errors:
+        if reg == warning:
+          sublime.status_message(err)
+          return
+    else:
+      sublime.status_message("")


### PR DESCRIPTION
So the status bar gets populated with the current line's error. I don't think that there are any major UX changes made other than the status bar getting updated. Tackles issue #14.
