### PR TITLE
The doc is now on par with the JSHint specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This plugin can be set to automatically lint when a file is saved or the current
 Note that live linting while *editing* is only available in Sublime Text 3.
 
 ## Using your own .jshintrc options
-The plugin looks for a `.jshintrc` file in the same directory as the source file you're linting (or one directory above if it doesn't exist, or in your home folder if everything else fails) and uses those options along the default ones. [Here](https://github.com/jshint/jshint/blob/master/examples/.jshintrc)'s an example of how it can look like.
+The plugin looks for a `.jshintrc` file in the same directory as the source file you're linting and, or one located recursively up one directory, all the way until the filesystem root. As well, it uses those options along the default ones. [Here](https://github.com/jshint/jshint/blob/master/examples/.jshintrc)'s an example of how it can look like.
 
 These are the default options used by this plugin:
 ```javascript


### PR DESCRIPTION
Yeah, I should have updated the README file in #13. It created a lot of confusions, and pull request #21 came along.

Although @victorporof later [commented](https://github.com/victorporof/Sublime-JSHint/pull/21#commitcomment-3686657) that we can find a compromise between the two. In the meanwhile, since the proposed changes have not been merged yet, I think this pull request is still relevant.
