### PR TITLE
Added os.path.sep to warning icon path

### DIFF
--- a/JSHint.py
+++ b/JSHint.py
@@ -139,7 +139,7 @@ following the instructions at:\n"""
         sublime.DRAW_SQUIGGLY_UNDERLINE |
         sublime.HIDE_ON_MINIMAP)
     else:
-      icon = ".." + os.path.sep + packageName + os.path.sep "warning"
+      icon = ".." + os.path.sep + packageName + os.path.sep + "warning"
       self.view.add_regions("jshint_errors", regions, "keyword", icon,
         sublime.DRAW_EMPTY |
         sublime.DRAW_OUTLINED |


### PR DESCRIPTION
This should fix https://github.com/victorporof/Sublime-JSHint/issues/41
