### PR TITLE
Option to hint JS files on load

### DIFF
--- a/JSHint.py
+++ b/JSHint.py
@@ -229,6 +229,12 @@ class JshintListener(sublime_plugin.EventListener):
       view.window().run_command("jshint", { "show_panel": False })
 
   @staticmethod
+  def on_load(view):
+    # Continue only if the current plugin settings allow this to happen.
+    if sublime.load_settings(SETTINGS_FILE).get("lint_on_load"):
+      v = view.window() if int(sublime.version()) < 3000 else view
+      v.run_command("jshint", { "show_panel": False })
+
   def on_selection_modified(view):
     display_to_status_bar(view, JshintListener.errors)
 

--- a/JSHint.sublime-settings
+++ b/JSHint.sublime-settings
@@ -6,6 +6,9 @@
 
   // Automatically lint on edit (Sublime Text 3 only).
   "lint_on_edit": false,
+  
+  // Automatically lint when a file is loaded.
+  "lint_on_load": false,
 
   // Automatically lint when a file is saved.
   "lint_on_save": false,


### PR DESCRIPTION
The vim module [vim-jshint](https://github.com/Shutnik/jshint2.vim#configuration) can optionally hint JS files on **open** as well as on **save**. I found this to be a handy setting so I've added the same ability to Sublime-JSHint in this PR.

Test and works fine in ST2 + ST3.
