### PR TITLE
Mirror Sublime-HTMLPrettify Subprocess and Logging Fixes

### DIFF
--- a/JSHint.py
+++ b/JSHint.py
@@ -30,7 +30,8 @@ class JshintCommand(sublime_plugin.TextCommand):
     os.remove(temp_file_path)
 
     # Dump any diagnostics and get the output after the identification marker.
-    print(self.get_output_diagnostics(output))
+    if PluginUtils.get_pref('print_diagnostics'):
+      print(self.get_output_diagnostics(output))
     output = self.get_output_data(output)
 
     # We're done with linting, rebuild the regions shown in the current view.
@@ -302,4 +303,4 @@ class PluginUtils:
     else:
       # Handle all OS in Python 3.
       run = '"' + '" "'.join(cmd) + '"'
-      return subprocess.check_output(run, stderr=subprocess.STDOUT, shell=True)
+      return subprocess.check_output(run, stderr=subprocess.STDOUT, shell=True, env=os.enviorn)

--- a/JSHint.sublime-settings
+++ b/JSHint.sublime-settings
@@ -21,5 +21,8 @@
   "lint_on_save": false,
 
   // Highlight problematic regions when selected.
-  "highlight_selected_regions": false
+  "highlight_selected_regions": false,
+
+  // Log the settings passed to JSHint from `.jshintrc`.
+  "print_diagnostics": true
 }


### PR DESCRIPTION
- Explicitly pass `os.environ` to `subprocess.check_output()`. Fixes
  bug in which the subprocess failed to inherit the package's environment,
  so `PluginUtils`' checks could find the Node binary but the new
  process could not.
- Add `print_diagnostics` setting, allowing the user to suppress verbose
  logging of JSBeautify's configuration.
