### PR TITLE
Remove deprecated globalstrict

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,7 +10,7 @@
   "browser": true,
   "esnext": true,
   "globals": {},
-  "globalstrict": true,
+  "strict": "global",
   "undef": true,
   "unused": true
 }


### PR DESCRIPTION
According to the docs (http://jshint.com/docs/options/), `globalstrict` 
is deprecated and should be replaced with `strict`. As an added bonus, 
this solved https://github.com/victorporof/Sublime-JSHint/issues/126
for me.