### PR TITLE
Prevents errors like: ValueError: invalid literal for int() with base 10: 'NaN'

### DIFF
--- a/JSHint.py
+++ b/JSHint.py
@@ -51,7 +51,7 @@ class JshintCommand(sublime_plugin.TextCommand):
         continue
 
       symbol_name = re.match("('[^']+')", description)
-      hint_point = self.view.text_point(int(line_no) - 1, int(column_no) - 1)
+      hint_point = self.view.text_point(int(line_no) - 1, int(column_no if column_no != "NaN" else "1") - 1)
       if symbol_name:
         hint_region = self.view.word(hint_point)
       else:


### PR DESCRIPTION
https://github.com/victorporof/Sublime-JSHint/issues/128