### PR TITLE
Human readable message instead of "Incompatible values for 'undefined' and 'undefined' linting options"

### DIFF
--- a/scripts/run.js
+++ b/scripts/run.js
@@ -194,11 +194,13 @@ function doLint(data, options, globals, lineOffset, charOffset) {
 
       // Do some formatting if the error data is available.
       if (e.raw) {
-        var message = e.raw
-          .replace("{a}", e.a)
-          .replace("{b}", e.b)
-          .replace("{c}", e.c)
-          .replace("{d}", e.d);
+        var message = e.reason;
+
+        if(e.a !== undefined && e.b !== undefined && e.c !== undefined && e.d !== undefined)
+          message = e.raw.replace("{a}", e.a)
+                         .replace("{b}", e.b)
+                         .replace("{c}", e.c)
+                         .replace("{d}", e.d);
 
         console.log([e.line + lineOffset, e.character + charOffset, message].join(" :: "));
       }


### PR DESCRIPTION
The issue with 'undefined' and 'undefined' probably lies deeper than a simple raw error message, but this commit at least makes them readable. Where you would usually get the message "Incompatible values for the 'undefined' of 'undefined' linting options" you will now be able to pinpoint the error with actual fields e.g. "Incompatible values for the 'strict' of 'globalstrict' linting options".
